### PR TITLE
Fix bugs: mpstat AM/PM, UTC time alignment, mllog already in UTC, plo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 plots/
 
+data/8gpu_*
+data/8gpus_*
 data/4gpu_*
 data/4gpus_*
 data/2gpu_*

--- a/data/mllog_UNIX_to_UTC_ts.py
+++ b/data/mllog_UNIX_to_UTC_ts.py
@@ -3,6 +3,7 @@ import json
 import argparse
 import numpy as np
 
+
 def process_timeline(datadir):
     """
     Convert the UNIX timestamps of the mllog to UTC timestamp
@@ -17,7 +18,8 @@ def process_timeline(datadir):
 
     for i, log in enumerate(all_logs):
 
-        ux_time = np.datetime64(log["time_ms"], "ms") + np.timedelta64(5, "h")
+        # UNIX timestamps are in milliseconds and already in UTC
+        ux_time = np.datetime64(log["time_ms"], "ms")
 
         key_parts = log["key"].split("_")
 

--- a/data/pid_names.py
+++ b/data/pid_names.py
@@ -11,6 +11,16 @@ def get_fields(line):
 def main(data_dir, output_dir):
 
     pids_trace = os.path.join(data_dir, "pids_tids.out")
+
+    if not os.path.isfile(pids_trace):
+        print(f"pids_tids.out not found. Looking for pids.out")
+
+    pids_trace = os.path.join(data_dir, "pids.out")
+
+    if not os.path.isfile(pids_trace):
+        print(f"pids.out not found! Failed.")
+        exit()
+        
     pids_trace = open(pids_trace, 'r')
 
     # Identify the run method

--- a/data/ts_to_start_end.py
+++ b/data/ts_to_start_end.py
@@ -11,7 +11,7 @@ def main(filename, outdir):
     infile = open(filename, "r")
     outfile = open(f"{outdir}/st_end_data_{pid}", "w")
 
-    for line in infile:
+    for i, line in enumerate(infile):
         try:
             cols = line.split(",")
             ts_end = np.datetime64(cols[0])
@@ -19,7 +19,7 @@ def main(filename, outdir):
             ts_start = ts_end - lat
             outfile.write(f"{ts_start},{ts_end},{cols[1]}\n")
         except Exception as e:
-            print(e)
+            print(f"\t{filename} line {i}: {e}. Continuing.")
             continue
 
 

--- a/tests/data/cpu_gpu_test.py
+++ b/tests/data/cpu_gpu_test.py
@@ -1,0 +1,33 @@
+import unittest
+
+# Hack to be able to import scripts in data knowing this isn't setup as a proper python package
+import sys
+sys.path.append('../..')
+
+from data import cpu_gpu
+
+class TestCPUTraceTimeConversion(unittest.TestCase):
+
+    def test_process_cpu_data_PM(self):
+        line = "04:34:52 PM  all    4.03    0.00    1.94    1.54    0.00    0.24    0.00    0.00    0.00   92.25"
+        processed = cpu_gpu.split_cpu_trace_line_cols(line)
+        self.assertEqual(processed[0], "16:34:52")
+
+    def test_process_cpu_data_PM_limit(self):
+        line = "11:59:59 PM  all    4.03    0.00    1.94    1.54    0.00    0.24    0.00    0.00    0.00   92.25"
+        processed = cpu_gpu.split_cpu_trace_line_cols(line)
+        self.assertEqual(processed[0], "23:59:59")
+
+    def test_process_cpu_data_PM_next_day(self):
+        line = "12:00:00 AM  all    4.03    0.00    1.94    1.54    0.00    0.24    0.00    0.00    0.00   92.25"
+        processed = cpu_gpu.split_cpu_trace_line_cols(line)
+        self.assertEqual(processed[0], "00:00:00")
+
+    def test_process_cpu_data_noon(self):
+        line = "12:00:00 PM  all    4.03    0.00    1.94    1.54    0.00    0.24    0.00    0.00    0.00   92.25"
+        processed = cpu_gpu.split_cpu_trace_line_cols(line)
+        self.assertEqual(processed[0], "12:00:00")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/timeline.py
+++ b/timeline.py
@@ -135,7 +135,6 @@ def plot_pids_timeline_cpu_gpu(data_dir, title, start=None, end=None, xformat="%
     ax2.legend(loc="center right")
 
 
-    #
     # Plot PIDs
     #
     for i, pid in enumerate(pids):
@@ -152,6 +151,11 @@ def plot_pids_timeline_cpu_gpu(data_dir, title, start=None, end=None, xformat="%
             df = df[df["start_date"] >= np.datetime64(start)]
         if end is not None:
             df = df[df["end_date"] <= np.datetime64(end)]
+
+        # If the DataFrame is empty after filtering, skip
+        if len(df) == 0:
+            print(f"This timerange is empty for pid {pid}. Skipping.")
+            continue
 
         # Can't define this earlier
         masks = {
@@ -204,11 +208,17 @@ def plot_pids_timeline_cpu_gpu(data_dir, title, start=None, end=None, xformat="%
     if margin is None:
         margin = np.timedelta64(5, "s")
 
-    ax.set_xlim(
-        df.start_date.min() - margin,
-        df.end_date.max() + margin,
-    )
-
+    # Sometimes the range we try to plot contains nothing so the limits are NaT
+    # and the program throws a value error "Axis limits cannot be NaN or Inf"
+    try:
+        ax.set_xlim(
+            df.start_date.min() - margin,
+            df.end_date.max() + margin,
+        )
+    except Exception as e:
+        print(f"Exception caught while trying to set graph limits: {e}")
+        print("Skipping this graph.")
+        return
     #
     # Plot the timeline
     #


### PR DESCRIPTION
Fix multiple bugs: 
- mpstat now prints out AM/PM timestamps
- mllog timestamp is already in UTC
- Eastern time is actually UTC-4, not UTC-5
- plotting crashed when desired range contains no data
- handle interleaving lines in raw traces better
- Add printing of oddities during trace preprocessing, with line numbers
- Add a unit test -- we should add more of these to make the repo more robust