### PR TITLE
Solved No date / Two dates in one row problem in gpu_avg.csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,7 @@ notes/
 ckpt_*
 unique_pids
 
+data/results_collection
+data/scaled_traces_results
 # Include the example trace data
 !data/4gpu_test_data.tar.gz

--- a/data/cpu_gpu.py
+++ b/data/cpu_gpu.py
@@ -38,15 +38,17 @@ def calc_avg_gpu_usage(gpu_trace, num_gpus):
         mem = []
         fb = []
 
+        first_rank0 = False # flag sets to true if we encountered rank 0 at least once and only once
         for i, line in enumerate(line_batch):
             try:
                 cols = " ".join(line.split()).replace("-", "0").split(" ")
-                if cols[2] == "0":
-                    # Combine cols 0 and 1 into a UTC timestamp
+                if cols[2] == "0" and not first_rank0:
+                    # Combine cols 0 and 1 into a UTC timestamp for every $num_gpus (ex: 8, 4, ...) lines
                     date = cols[0]
                     ts = f"{date[0:4]}-{date[4:6]}-{date[6:8]}T{cols[1]}"
                     ts = str(np.datetime64(ts) + np.timedelta64(UTC_TIME_DELTA, "h"))
                     wcols.append(ts)
+                    first_rank0 = True
                 # Extract values
                 sm.append(int(cols[5]))
                 mem.append(int(cols[6]))
@@ -61,7 +63,9 @@ def calc_avg_gpu_usage(gpu_trace, num_gpus):
         wcols.append(str(mean(mem)))
         wcols.append(str(mean(fb)))
 
-        outcsv.write(",".join(wcols) + "\n")
+        # only write to csv if saw rank 0 at least once and only once
+        if first_rank0:
+            outcsv.write(",".join(wcols) + "\n")
 
     infile.close()
     outcsv.close()


### PR DESCRIPTION
There is a problem when preprocessing gpu.all into gpu_avg.csv in cpu_gpu.py. The issue is recorded in 
`/dl-bench/ruoyudeng/trace_visuals/data/results_collection/bug_record/before_fix_data
/ta_8gpu_Original_200GB_20220902233247/gpu_data/gpu_avg.csv` (will be referred as gpu_avg.csv for short)
and `/dl-bench/ruoyudeng/trace_visuals/data/results_collection
/bug_record/before_fix_data/ta_8gpu_Original_200GB_20220902233247/gpu_data/gpu.all` (will be referred as gpu.all for short).


**2 dates problem:** Line 1732 in gpu_avg.csv displayed: `2022-09-03T04:06:58,2022-09-03T04:06:58,32.625,5.25,10835.125` because both line 13846 and line 13847 in gpu.all have rank 0, which means 2 dates will be appended. 

**No date problem:** Line 3154: `68.5,0,28585` in gpu_avg.csv contains no date because there is no line with rank 0 in the last batch of lines in gpu.all.

Such two problems are resolved, and the correct preprocessed data is stored as
`/dl-bench/ruoyudeng/trace_visuals/data/results_collection/bug_record/after_fix_data
/ta_8gpu_Original_200GB_20220902233247/gpu_data/gpu_avg.csv`.

